### PR TITLE
Include path and file name for disk images to make more verbose.

### DIFF
--- a/_mister/update/AO486_Update_Top300_updater.sh
+++ b/_mister/update/AO486_Update_Top300_updater.sh
@@ -144,7 +144,7 @@ find_secondary_disk_image()
 	secondary_disk_image="${ao486_dir}/${secondary_disk_image}"
 	
 	if [ ! -f "${secondary_disk_image}" ]; then
-		echo "Couldn't find disk image in \"${ao486_dir}\"."
+		echo "Couldn't find disk image: \" ${secondary_disk_image}\"."
 		exit 1
 	fi
 }
@@ -164,7 +164,7 @@ find_primary_disk_image()
 	primary_disk_image="${ao486_dir}/${primary_disk_image}"
 	
 	if [ ! -f "${primary_disk_image}" ]; then
-		echo "Couldn't find disk image in \"${ao486_dir}\"."
+		echo "Couldn't find disk image: \"${primary_disk_image}\"."
 		exit 1
 	fi
 }


### PR DESCRIPTION
A user was having issues with the update script and just saw "Couldn't find disk image in "media/fat/games/ao486".
https://www.reddit.com/r/fpgagaming/comments/q9icue/update_problem_with_top_300/

Updated so the error will pass the path and filename it's looking for.