### PR TITLE
Default BASE_PATH within script

### DIFF
--- a/_mister/AO486_Update_Top300_Pack.sh
+++ b/_mister/AO486_Update_Top300_Pack.sh
@@ -74,6 +74,9 @@ if [[ -f "${INI_PATH}" ]] ; then
 	dos2unix < "${INI_PATH}" 2> /dev/null | grep -v "^exit" > ${TMP}
 	source ${TMP}
 	rm -f ${TMP}
+else
+	# Remove need for default INI file
+	export BASE_PATH=/media/fat
 fi
 
 # test network and https by pinging the target website 


### PR DESCRIPTION
This exports BASE_PATH within the shell script, so the ini file doesn't need to hang out in the scripts directory.