### PR TITLE
Game Fix: Return To Zork paths fixed

### DIFF
--- a/games/RETURNTO/rzork/RTZ-CD/MT32/RTZ.BAT
+++ b/games/RETURNTO/rzork/RTZ-CD/MT32/RTZ.BAT
@@ -1,6 +1,5 @@
 @echo off
-C:
-cd \RZORK
+
 LOADHIGH DRIVERS\SB16
 
 DIR D: > nul

--- a/games/RETURNTO/rzork/RTZ-CD/SC55/RTZ.BAT
+++ b/games/RETURNTO/rzork/RTZ-CD/SC55/RTZ.BAT
@@ -1,6 +1,5 @@
 @echo off
-C:
-cd \RZORK
+
 LOADHIGH DRIVERS\SB16
 
 DIR D: > nul


### PR DESCRIPTION
When launching Return to Zork and selecting option 2 (MT32) or option 3 (Sound Canvas) launch would fail.

Fix modifies the RTZ.BAT files associated with these options.
