### PR TITLE
Game Fix: ThemePark paths fixed

### DIFF
--- a/THEME.CD/THEME.BAT
+++ b/THEME.CD/THEME.BAT
@@ -1,5 +1,5 @@
-@D:
-@cd D:\game 
+@F:
+@cd F:\game 
 :START
 @intro -E:/THEME.CD
 @main -cD:/game/ -dE:/THEME.CD/ -l0

--- a/games/THEMEPAR/ThemPark/THEME.CD/THEME.BAT
+++ b/games/THEMEPAR/ThemPark/THEME.CD/THEME.BAT
@@ -1,5 +1,5 @@
-@D:
-@cd D:\game 
+@F:
+@cd F:\game 
 :START
 @intro -E:/THEME.CD
 @main -cD:/game/ -dE:/THEME.CD/ -l0


### PR DESCRIPTION
On the current AO486 core D:\THEME.CD directory is unreadable. I don't quite understand the differences in how F: and D: are mapped. However in testing the F: drive is stable and reads the CD without issue.

The change here is simple and just substitutes the D: drive for the F: drive in THEME.BAT